### PR TITLE
Дададзены канфігі для ботаў

### DIFF
--- a/.github/config.yml
+++ b/.github/config.yml
@@ -15,3 +15,29 @@ firstPRMergeComment: >
   УРА! Мы толькі што прынялі і зклеілі першы PR ад цябе! 🎉🎉🎉 Чакаем новых подзьвігаў!
   ![image](https://media.giphy.com/media/5gXYzsVBmjIsw/giphy.gif)
 # It is recommended to include as many gifs and emojis as possible!
+
+
+
+
+
+
+# Configuration for Request-info bot - https://github.com/behaviorbot/request-info
+# *Required* Comment to reply with
+requestInfoReplyComment: >
+  Мы былі б ўдзячныя, калі вы маглі б даць нам больш інфармацыі аб гэтай іш'ю!
+
+# *OPTIONAL* default titles to check against for lack of descriptiveness
+# MUST BE ALL LOWERCASE
+#requestInfoDefaultTitles:
+#  - update readme.md
+#  - updates
+
+
+# *OPTIONAL* Label to be added to Issues and Pull Requests with insufficient information given
+# requestInfoLabelToAdd: needs-more-info
+
+# *OPTIONAL* Only warn about insufficient information on these events type
+# Keys must be lowercase. Valid values are 'issue' and 'pullRequest'
+requestInfoOn:
+  pullRequest: false
+  issue: true

--- a/.github/config.yml
+++ b/.github/config.yml
@@ -1,0 +1,17 @@
+# Config for Welcome bot https://github.com/behaviorbot/welcome
+# Configuration for new-issue-welcome - https://github.com/behaviorbot/new-issue-welcome
+# Comment to be posted to on first time issues
+newIssueWelcomeComment: >
+  Дзякуй за адкрыцце тваёй першай іш'ю ў гэтым рэпазіторыі!
+
+# Configuration for new-pr-welcome - https://github.com/behaviorbot/new-pr-welcome
+# Comment to be posted to on PRs from first time contributors in your repository
+newPRWelcomeComment: >
+  Дзякуй за стварэнне твайго першага pull request тут! Калі ласка азнаемся з [правіламі афармлення PR](/CONTRIBUTING.md).
+
+# Configuration for first-pr-merge - https://github.com/behaviorbot/first-pr-merge
+# Comment to be posted to on pull requests merged by a first time user
+firstPRMergeComment: >
+  УРА! Мы толькі што прынялі і зклеілі першы PR ад цябе! 🎉🎉🎉 Чакаем новых подзьвігаў!
+  ![image](https://media.giphy.com/media/5gXYzsVBmjIsw/giphy.gif)
+# It is recommended to include as many gifs and emojis as possible!

--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,23 @@
+# Config for Stale bot: https://probot.github.io/apps/stale/
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 365
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - pinned
+  - security
+  - recurring
+  - Epic
+# Label to use when marking an issue as stale
+staleLabel: нясвежы
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  Гэтая іш'ю была аўтаматычна пазначаецца як нясвежы, таму што не было ў апошні час неактыўны на працягу 365 дзён.
+  Калі ласка выдаліце "нясвежы" лэйбл калі вы не згодны з гэтым.
+  Калі вы гэтага не зробіце, я буду аўтаматычна зыкрыю іш'ю праз 7 дзён.
+  Гэта вельмі важна, каб мы не закрывалі іш'ю, якія не павінны быць закрытыя, так што калі ласка адрэагкйце на гэтае апавяшчэнне (будзь коцікам! 🐈).
+  Дзякуй!
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: >
+  Гэтае іш'ю закрыта, таму што гэта яно было неяктыўным 365 дзён, і яшчэ 7 дзён пасля маркіроўкі яго як «нясвежы» ніхто не адрэагаваў на гэта і не зняў гэтую пазнаку.

--- a/.github/weekly-digest.yml
+++ b/.github/weekly-digest.yml
@@ -1,0 +1,7 @@
+# Configuration for weekly-digest - https://github.com/apps/weekly-digest
+publishDay: sun
+canPublishIssues: true
+canPublishPullRequests: true
+canPublishContributors: true
+canPublishStargazers: true
+canPublishCommits: true


### PR DESCRIPTION
 PR да issue Дадаць канфігі для GitHub ботаў #153

Я на ўпэўнены калі пачнуць працаваць боты, але думаю пасля таго як канфігі будуць дададзены у галоўны брэнч репазіторыя, на дадзены момант гэта `master`. АЛЕ на маю думку лепей галоўнай зрабіць `dev` галіну. Гэта мяняе толькі адну штуку: па дэфолку GitHub пачне капазваць dev галіну і калі, напрыклад Віктар, вырашыць паправіць README.md, то ен паправіць яего ў `dev`, што на маю думку нават лепей

Нават яшчэ лепей: усе PR па дэфолту будуць стварацца з `dev` галіной як base branch (зараз мы мяняем гэта кожны раз рукамі).

Мяняецца гэта тут (памяняць можа толькі адмін):
![image](https://user-images.githubusercontent.com/5278175/50936622-794df680-1481-11e9-8aea-f82f1bfbc353.png)

Заўваж, тут жа есьць налады зрабіць любыя галіны абароненымі ад прамых камітаў у іх (можнатолькі праз ПР), што добрая ідэя для нашага master branch.

