### PR TITLE
#237 Fix package name

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
-    "name": "Doika",
+    "name": "diglabby/doika",
     "description": "Doika",
-    "keywords": ["vue"],
+    "keywords": ["vue", "laravel", "bePaid"],
     "license": "MIT",
     "type": "project",
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "50e4725026b1550bf464e8639d46468a",
+    "content-hash": "487804dc9fb8afe668657d148445cb7f",
     "packages": [
         {
             "name": "arcanedev/log-viewer",


### PR DESCRIPTION
Fixes #237 
Composer кідае наступны warning
>Deprecation warning: Your package name Doika is invalid, it should have a vendor name, a forward slash, and a package name. The vendor and package name can be words separated by -, . or _. The complete name should match "[a-z0-9](%5B_.-%5D?%5Ba-z0-9%5D+)_/[a-z0-9](%5B_.-%5D?%5Ba-z0-9%5D+)_". Make sure you fix this as Composer 2.0 will error.