### PR TITLE
Add webhook handler for "donated" event from bePaid

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -1,0 +1,3 @@
+<?php
+
+Route::post('doika/webhooks/bepaid/donated/{campaignId}', 'Webhooks\PaymentGateways\BePaidWebhookHandler@donated')->name('webhooks.bepaid.donated');

--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -19,7 +19,3 @@ Route::delete('/donators/{id}', 'Dashboard\DonatorController@delete')->name('das
 Route::get('/{vue_capture?}', 'Dashboard\DashboardController@index')
     ->where('vue_capture', '[\/\w\.-]*')
     ->name('dashboard.home');
-
-Route::post('doika/webhooks/bepaid/donated/{campaignId}', function () {
-    echo 'stub';
-})->name('webhooks.bepaid.donated');

--- a/src/Http/Controllers/Dashboard/CampaignController.php
+++ b/src/Http/Controllers/Dashboard/CampaignController.php
@@ -15,7 +15,7 @@ final class CampaignController extends Controller
     public function show(int $campaignId)
     {
         return view('backend.admin.campaign', [
-            'camplaign' => factory(Campaign::class)->make(['id' => $campaignId])
+            'campaign' => factory(Campaign::class)->make(['id' => $campaignId])
         ]);
     }
 

--- a/src/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandler.php
+++ b/src/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandler.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Diglabby\Doika\Http\Controllers\Webhooks\PaymentGateways;
+
+use App\Http\Controllers\Controller;
+use Diglabby\Doika\Models\Transaction;
+use Illuminate\Http\Request;
+
+/**
+ * @see https://docs.bepaid.by/ru/webhooks
+ */
+final class BePaidWebhookHandler extends Controller
+{
+    public function donated(Request $request, int $campaignId)
+    {
+        \Log::debug('bePaid donated webhook', $request->all());
+
+        Transaction::query()->create([
+            'campaign_id' => $campaignId,
+            'payment_gateway' => 'bePaid',
+            'payment_gateway_transaction_id' => $request->json('transaction.uid'),
+            'amount' => $request->json('transaction.amount'),
+            'currency' => $request->json('transaction.currency'),
+            'status' => Transaction::STATUS_SUCCESSFUL,
+            'status_message' => $request->json('transaction.payment.message'),
+        ]);
+    }
+}

--- a/src/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandler.php
+++ b/src/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandler.php
@@ -20,7 +20,7 @@ final class BePaidWebhookHandler extends Controller
         /** @var Donator $donator */
         $donator = Donator::query()->firstOrCreate(['email' => $request->json('transaction.customer.email')]);
 
-        Transaction::query()->create([
+        $transaction = new Transaction([
             'campaign_id' => $campaignId,
             'donator_id' => $donator->id,
             'payment_gateway' => 'bePaid',
@@ -30,6 +30,7 @@ final class BePaidWebhookHandler extends Controller
             'status' => Transaction::STATUS_SUCCESSFUL,
             'status_message' => $request->json('transaction.payment.message'),
         ]);
+        $transaction->save();
 
         return response('', Response::HTTP_CREATED);
     }

--- a/src/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandler.php
+++ b/src/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandler.php
@@ -3,6 +3,7 @@
 namespace Diglabby\Doika\Http\Controllers\Webhooks\PaymentGateways;
 
 use App\Http\Controllers\Controller;
+use Diglabby\Doika\Models\Donator;
 use Diglabby\Doika\Models\Transaction;
 use Illuminate\Http\Request;
 
@@ -15,8 +16,12 @@ final class BePaidWebhookHandler extends Controller
     {
         \Log::debug('bePaid donated webhook', $request->all());
 
+        /** @var Donator $donator */
+        $donator = Donator::query()->firstOrCreate(['email' => $request->json('transaction.customer.email')]);
+
         Transaction::query()->create([
             'campaign_id' => $campaignId,
+            'donator_id' => $donator->id,
             'payment_gateway' => 'bePaid',
             'payment_gateway_transaction_id' => $request->json('transaction.uid'),
             'amount' => $request->json('transaction.amount'),

--- a/src/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandler.php
+++ b/src/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandler.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\Controller;
 use Diglabby\Doika\Models\Donator;
 use Diglabby\Doika\Models\Transaction;
 use Illuminate\Http\Request;
+use Illuminate\Http\Response;
 
 /**
  * @see https://docs.bepaid.by/ru/webhooks
@@ -29,5 +30,7 @@ final class BePaidWebhookHandler extends Controller
             'status' => Transaction::STATUS_SUCCESSFUL,
             'status_message' => $request->json('transaction.payment.message'),
         ]);
+
+        return response('', Response::HTTP_CREATED);
     }
 }

--- a/src/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandler.php
+++ b/src/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandler.php
@@ -14,7 +14,7 @@ final class BePaidWebhookHandler extends Controller
 {
     public function donated(Request $request, int $campaignId)
     {
-        \Log::debug('bePaid donated webhook', $request->all());
+        \Log::debug('bePaid donated webhook', ['headers' => $request->headers->all(), 'input' => $request->all(),]);
 
         /** @var Donator $donator */
         $donator = Donator::query()->firstOrCreate(['email' => $request->json('transaction.customer.email')]);

--- a/src/Models/Donator.php
+++ b/src/Models/Donator.php
@@ -21,6 +21,8 @@ use Illuminate\Support\Carbon;
  */
 final class Donator extends Model
 {
+    protected $guarded = [];
+
     public function subscriptions(): HasMany
     {
         $this->hasMany(Subscription::class);

--- a/src/Models/Transaction.php
+++ b/src/Models/Transaction.php
@@ -21,9 +21,11 @@ use Illuminate\Support\Carbon;
  */
 final class Transaction extends Model
 {
+    protected $guarded = [];
+
     /** @see https://docs.bepaid.by/ru/gateway/statuses */
-    private const STATUS_SUCCESSFULL = 'successful';
-    private const STATUS_FAILED = 'failed';
-    private const STATUS_INCOMPLETE = 'incomplete';
-    private const STATUS_EXPIRED = 'expired';
+    public const STATUS_SUCCESSFUL = 'successful';
+    public const STATUS_FAILED = 'failed';
+    public const STATUS_INCOMPLETE = 'incomplete';
+    public const STATUS_EXPIRED = 'expired';
 }

--- a/src/Providers/RouteServiceProvider.php
+++ b/src/Providers/RouteServiceProvider.php
@@ -26,9 +26,17 @@ final class RouteServiceProvider extends BasicRouteServiceProvider
      */
     public function map()
     {
+        $this->mapApiRoutes();
         $this->mapWidgetRoutes();
         $this->mapDashboardRoutes();
         $this->mapRedirectRoutes();
+    }
+
+    protected function mapApiRoutes()
+    {
+        Route::middleware('api')
+            ->namespace($this->namespace)
+            ->group(base_path('routes/api.php'));
     }
 
     protected function mapWidgetRoutes()

--- a/tests/Feature/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandlerTest.donated.json
+++ b/tests/Feature/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandlerTest.donated.json
@@ -1,0 +1,47 @@
+{
+  "transaction":{
+    "customer":{
+      "ip":"127.0.0.1",
+      "email":"john@example.com"
+    },
+    "credit_card":{
+      "holder":"John Doe",
+      "stamp":"3709786942408b77017a3aac8390d46d77d181e34554df527a71919a856d0f28",
+      "token":"d46d77d181e34554df527a71919a856d0f283709786942408b77017a3aac8390",
+      "brand":"visa",
+      "last_4":"0000",
+      "first_1":"4",
+      "exp_month":5,
+      "exp_year":2022
+    },
+    "billing_address":{
+      "first_name":"John",
+      "last_name":"Doe",
+      "address":"1st Street",
+      "country":"US",
+      "city":"Denver",
+      "zip":"96002",
+      "state":"CO",
+      "phone":null
+    },
+    "payment":{
+      "auth_code":"654321",
+      "bank_code":"05",
+      "rrn":"999",
+      "ref_id":"777888",
+      "message":"Payment was approved",
+      "gateway_id":317,
+      "billing_descriptor":"TEST GATEWAY BILLING DESCRIPTOR",
+      "status":"successful"
+    },
+    "uid":"1-310b0da80b",
+    "status":"successful",
+    "message":"Successfully processed",
+    "amount":100,
+    "test":false,
+    "currency":"BYN",
+    "description":"Donate",
+    "tracking_id": "my_tracking_id",
+    "type":"payment"
+  }
+}

--- a/tests/Feature/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandlerTest.php
+++ b/tests/Feature/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandlerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Webhooks\PaymentGateways;
+
+use Diglabby\Doika\Models\Campaign;
+use Diglabby\Doika\Models\Transaction;
+use Tests\TestCase;
+
+class BePaidWebhookHandlerTest extends TestCase
+{
+    /** @test */
+    function it_creates_successful_transaction_from_webhook_request()
+    {
+        $this->withoutExceptionHandling();
+        $campaign = factory(Campaign::class)->create();
+
+        $response = $this->postJson(
+            route('webhooks.bepaid.donated', $campaign->id),
+            $this->loadRequestPayload('BePaidWebhookHandlerTest.donated.json')
+        );
+
+        $response->assertOk();
+        $this->assertDatabaseHas('transactions', [
+            'campaign_id' => $campaign->id,
+            'subscription_id' => null,
+            'payment_gateway' => 'bePaid',
+            'payment_gateway_transaction_id' => '1-310b0da80b',
+            'amount' => 100,
+            'currency' => 'BYN',
+            'status' => Transaction::STATUS_SUCCESSFUL,
+        ]);
+    }
+
+    public function loadRequestPayload(string $fixtureFilename): array
+    {
+        $fixtureFile = __DIR__.DIRECTORY_SEPARATOR.$fixtureFilename;
+        return json_decode(file_get_contents($fixtureFile), true);
+    }
+}

--- a/tests/Feature/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandlerTest.php
+++ b/tests/Feature/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandlerTest.php
@@ -22,7 +22,7 @@ class BePaidWebhookHandlerTest extends TestCase
             $this->loadRequestPayload('BePaidWebhookHandlerTest.donated.json')
         );
 
-        $response->assertOk();
+        $response->assertStatus(201);
         $this->assertDatabaseHas('transactions', [
             'campaign_id' => $campaign->id,
             'subscription_id' => null,

--- a/tests/Feature/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandlerTest.php
+++ b/tests/Feature/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandlerTest.php
@@ -32,6 +32,9 @@ class BePaidWebhookHandlerTest extends TestCase
             'currency' => 'BYN',
             'status' => Transaction::STATUS_SUCCESSFUL,
         ]);
+        $this->assertDatabaseHas('donators', [
+            'email' => 'john@example.com',
+        ]);
     }
 
     public function loadRequestPayload(string $fixtureFilename): array

--- a/tests/Feature/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandlerTest.php
+++ b/tests/Feature/Http/Controllers/Webhooks/PaymentGateways/BePaidWebhookHandlerTest.php
@@ -4,10 +4,13 @@ namespace Tests\Feature\Http\Controllers\Webhooks\PaymentGateways;
 
 use Diglabby\Doika\Models\Campaign;
 use Diglabby\Doika\Models\Transaction;
+use Illuminate\Foundation\Testing\RefreshDatabase;
 use Tests\TestCase;
 
 class BePaidWebhookHandlerTest extends TestCase
 {
+    use RefreshDatabase;
+
     /** @test */
     function it_creates_successful_transaction_from_webhook_request()
     {


### PR DESCRIPTION
Праглядзець пасля прыняцця #310 Add bePaid payment gateway service (гэты ПР пабудаваны на базе #310)

## Задача
Рэалізваць webhook handler на стварэнне Donate/Transaction для bePaid #311 (closes #311)

##  Рэалізацыя
1. Выкарыстана `api` middleware group бо для вебхукаў мы сессіі не захоўваем
1. Створаны новы кантроллер `BePaidWebhookHandler` каб апрацоўваць 
1. Дададзены тэсты на падставе дадзеных са старонкі https://docs.bepaid.by/ru/webhooks


## Невырашаныя пытанні
1. Адкуль мы ведаем email, @rizomaa кажа што мы яго будзем пытаць толькі пры прыняцці рэкурэнтных плацяжоў
1. Як валідаваць webhook request каб любыя іншыя карыстальнікі інтэрнэта не змаглі дасылаць фэйкавую інфармацыю на наш API. Каб закрыць гэта пытанне трэба ведаць адкуль bePaid дасылае webhook requests і з якімі загалоўкамі ЦІ можна па uuid транзакцыі дасылаць запыт і правяраць ці існуе такая на bepaid
1.  Што вяртаем з `\Diglabby\Doika\Http\Controllers\Webhooks\PaymentGateways\BePaidWebhookHandler::donated` , у прынцыпе гэта можа спатрэбіцца толькі для адмінкі bepaid (калі там есьць магчымасць паказваць нашыя адказы)