### PR TITLE
Перанакіраванне пасля аплаты bePaid  (бэкэнд толькі)

### DIFF
--- a/resources/views/widget/pages/campaigns/donation-result.blade.php
+++ b/resources/views/widget/pages/campaigns/donation-result.blade.php
@@ -1,0 +1,7 @@
+<?php
+/**
+ * @var string $status
+ * @var \Diglabby\Doika\Models\Campaign $campaign
+ */
+?>
+{{ $status }}

--- a/resources/views/widget/pages/campaigns/donation-result.blade.php
+++ b/resources/views/widget/pages/campaigns/donation-result.blade.php
@@ -4,4 +4,4 @@
  * @var \Diglabby\Doika\Models\Campaign $campaign
  */
 ?>
-{{ $status }}
+Transaction status: {{ $status }}

--- a/routes/widget.php
+++ b/routes/widget.php
@@ -14,7 +14,7 @@
 
 Route::get('/', 'Widget\WidgetController@index')->name('widget.home');
 Route::get('campaigns/{campaignId}', 'Widget\CampaignController@show')->name('widget.campaign.show')->where('campaignId', '[0-9]+');
-Route::get('campaigns/{campaignId}/donation-result', 'Widget\CampaignDonationResultController@show')->name('widget.campaign.donation-result');
+Route::get('campaigns/{campaign}/donation-result', 'Widget\CampaignDonationResultController@show')->name('widget.campaign.donation-result');
 
 Route::get('help', 'Widget\HelpController@show')->name('widget.help.show');
 Route::get('feedback', 'Widget\FeedbackController@show')->name('widget.feedbacks.show');

--- a/routes/widget.php
+++ b/routes/widget.php
@@ -13,7 +13,8 @@
 */
 
 Route::get('/', 'Widget\WidgetController@index')->name('widget.home');
-Route::get('campaign/{campaignId}', 'Widget\CampaignController@show')->name('widget.campaign.show')->where('campaignId', '[0-9]+');
+Route::get('campaigns/{campaignId}', 'Widget\CampaignController@show')->name('widget.campaign.show')->where('campaignId', '[0-9]+');
+Route::get('campaigns/{campaignId}/donation-result', 'Widget\CampaignDonationResultController@show')->name('widget.campaign.donation.result');
 
 Route::get('help', 'Widget\HelpController@show')->name('widget.help.show');
 Route::get('feedback', 'Widget\FeedbackController@show')->name('widget.feedbacks.show');

--- a/routes/widget.php
+++ b/routes/widget.php
@@ -14,7 +14,7 @@
 
 Route::get('/', 'Widget\WidgetController@index')->name('widget.home');
 Route::get('campaigns/{campaignId}', 'Widget\CampaignController@show')->name('widget.campaign.show')->where('campaignId', '[0-9]+');
-Route::get('campaigns/{campaignId}/donation-result', 'Widget\CampaignDonationResultController@show')->name('widget.campaign.donation.result');
+Route::get('campaigns/{campaignId}/donation-result', 'Widget\CampaignDonationResultController@show')->name('widget.campaign.donation-result');
 
 Route::get('help', 'Widget\HelpController@show')->name('widget.help.show');
 Route::get('feedback', 'Widget\FeedbackController@show')->name('widget.feedbacks.show');

--- a/src/Http/Controllers/Widget/CampaignDonationResultController.php
+++ b/src/Http/Controllers/Widget/CampaignDonationResultController.php
@@ -5,14 +5,15 @@ namespace Diglabby\Doika\Http\Controllers\Widget;
 use App\Http\Controllers\Controller;
 use Diglabby\Doika\Models\Campaign;
 use Illuminate\Contracts\Support\Renderable;
+use Illuminate\Http\Request;
 
 final class CampaignDonationResultController extends Controller
 {
-    public function show(Campaign $campaign, string $status): Renderable
+    public function show(Campaign $campaign, Request $request): Renderable
     {
         return view('widget.pages.campaigns.donation-result', [
             'campaign' => $campaign,
-            'status' => $status,
+            'status' => $request->get('status'),
         ]);
     }
 }

--- a/src/Http/Controllers/Widget/CampaignDonationResultController.php
+++ b/src/Http/Controllers/Widget/CampaignDonationResultController.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Diglabby\Doika\Http\Controllers\Widget;
+
+use App\Http\Controllers\Controller;
+use Diglabby\Doika\Models\Campaign;
+use Illuminate\Contracts\Support\Renderable;
+
+final class CampaignDonationResultController extends Controller
+{
+    public function show(Campaign $campaign, string $status): Renderable
+    {
+        return view('widget.pages.campaigns.donation-result', [
+            'campaign' => $campaign,
+            'status' => $status,
+        ]);
+    }
+}

--- a/src/Services/PaymentGateways/BePaidPaymentGateway.php
+++ b/src/Services/PaymentGateways/BePaidPaymentGateway.php
@@ -46,10 +46,9 @@ final class BePaidPaymentGateway implements OffsitePaymentGateway
                 'version' => self::API_VERSION,
                 'attempts' => 3,
                 'settings' => [
-                    'success_url' => $appUrl.'status=success',
-                    'decline_url' => $appUrl.'status=decline',
-                    'fail_url' => $appUrl.'status=fail',
-                    'cancel_url' => $appUrl.'status=cancel',
+                    'success_url' => route('widget.campaign.donation.result', ['campaignId' => $campaign->id, 'status' => 'success']),
+                    'decline_url' => route('widget.campaign.donation.result', ['campaignId' => $campaign->id, 'status' => 'decline']),
+                    'fail_url' => route('widget.campaign.donated.result', ['campaignId' => $campaign->id, 'status' => 'fail']),
                     'notification_url' => route('webhooks.bepaid.donated', [$campaign->id]),
                     'language' => $this->config->get('app.locale'),
                 ],

--- a/src/Services/PaymentGateways/BePaidPaymentGateway.php
+++ b/src/Services/PaymentGateways/BePaidPaymentGateway.php
@@ -46,8 +46,8 @@ final class BePaidPaymentGateway implements OffsitePaymentGateway
                 'version' => self::API_VERSION,
                 'attempts' => 3,
                 'settings' => [
-                    'success_url' => route('widget.campaign.donation-result', ['campaignId' => $campaign->id, 'status' => 'success']),
-                    'decline_url' => route('widget.campaign.donation-result', ['campaignId' => $campaign->id, 'status' => 'decline']),
+                    'success_url' => route('widget.campaign.donation-result', ['campaign' => $campaign->id, 'status' => 'success']),
+                    'decline_url' => route('widget.campaign.donation-result', ['campaign' => $campaign->id, 'status' => 'decline']),
                     'fail_url' => route('widget.campaign.donated.result', ['campaignId' => $campaign->id, 'status' => 'fail']),
                     'notification_url' => route('webhooks.bepaid.donated', [$campaign->id]),
                     'language' => $this->config->get('app.locale'),

--- a/src/Services/PaymentGateways/BePaidPaymentGateway.php
+++ b/src/Services/PaymentGateways/BePaidPaymentGateway.php
@@ -46,8 +46,8 @@ final class BePaidPaymentGateway implements OffsitePaymentGateway
                 'version' => self::API_VERSION,
                 'attempts' => 3,
                 'settings' => [
-                    'success_url' => route('widget.campaign.donation.result', ['campaignId' => $campaign->id, 'status' => 'success']),
-                    'decline_url' => route('widget.campaign.donation.result', ['campaignId' => $campaign->id, 'status' => 'decline']),
+                    'success_url' => route('widget.campaign.donation-result', ['campaignId' => $campaign->id, 'status' => 'success']),
+                    'decline_url' => route('widget.campaign.donation-result', ['campaignId' => $campaign->id, 'status' => 'decline']),
                     'fail_url' => route('widget.campaign.donated.result', ['campaignId' => $campaign->id, 'status' => 'fail']),
                     'notification_url' => route('webhooks.bepaid.donated', [$campaign->id]),
                     'language' => $this->config->get('app.locale'),

--- a/tests/Feature/Http/Controllers/Widget/CampaignDonationResultControllerTest.php
+++ b/tests/Feature/Http/Controllers/Widget/CampaignDonationResultControllerTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Widget;
+
+use Diglabby\Doika\Models\Campaign;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class CampaignDonationResultControllerTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @test
+     * @dataProvider validTransactionStatusProvider
+     */
+    function it_disaplays_a_status_message($status)
+    {
+        $campaign = factory(Campaign::class)->create();
+
+        $response = $this->get(route('widget.campaign.donation-result', ['campaignId' => $campaign->id, 'status' => '']));
+
+        $response->assertSeeText($status);
+    }
+
+    function validTransactionStatusProvider(): array
+    {
+        return [
+            ['success'],
+            ['decline'],
+            ['fail'],
+        ];
+    }
+}

--- a/tests/Feature/Http/Controllers/Widget/CampaignDonationResultControllerTest.php
+++ b/tests/Feature/Http/Controllers/Widget/CampaignDonationResultControllerTest.php
@@ -18,7 +18,7 @@ class CampaignDonationResultControllerTest extends TestCase
     {
         $campaign = factory(Campaign::class)->create();
 
-        $response = $this->get(route('widget.campaign.donation-result', ['campaignId' => $campaign->id, 'status' => $status]));
+        $response = $this->get(route('widget.campaign.donation-result', ['campaign' => $campaign->id, 'status' => $status]));
 
         $response->assertSeeText($status);
     }

--- a/tests/Feature/Http/Controllers/Widget/CampaignDonationResultControllerTest.php
+++ b/tests/Feature/Http/Controllers/Widget/CampaignDonationResultControllerTest.php
@@ -18,7 +18,7 @@ class CampaignDonationResultControllerTest extends TestCase
     {
         $campaign = factory(Campaign::class)->create();
 
-        $response = $this->get(route('widget.campaign.donation-result', ['campaignId' => $campaign->id, 'status' => '']));
+        $response = $this->get(route('widget.campaign.donation-result', ['campaignId' => $campaign->id, 'status' => $status]));
 
         $response->assertSeeText($status);
     }


### PR DESCRIPTION
## Задачы
Рэалізаваць перанакіраванне пасля аплаты bePaid (closes #312)

паразмаўлялі учора, высветлілася што пакульку мы цяпер усе робім у iframe то і перанакіроваць будем толькі у межах яго. Адпаведна перанакіроўваем на старонку кампаніі (ня трэба ведаць бацькоўскі адрас старонкі)


PS: Я ня ведаю што паказваць на старонках пасля данэйта, гэта будуць рабіць фронтэндзеры, пакуль жа проста бэкэнд (у майер рэалізацыі старонка пасля данэйту вельмі простая: [donation-result.blade.php](https://github.com/diglabby/doika/blob/52902f2ad9465e9ceaf3334390e72cbdb6f5fc4d/resources/views/widget/pages/campaigns/donation-result.blade.php))


PPS: `cancel_url ` нейкая недакументаваная штука ў bePaid, не памятаю дзе я яе падгледзіў, але вырашыў выдаліць тут ад граха падалей (яна не абавязковая)