### PR TITLE
Test migrations on CI (travis)

### DIFF
--- a/.env.ci
+++ b/.env.ci
@@ -1,0 +1,10 @@
+APP_NAME=Doika
+APP_ENV=testing
+APP_KEY=
+APP_URL=http://localhost
+
+DOIKA_URL_SUBPATH=doika
+
+DB_DATABASE=doika
+DB_USERNAME=root
+DB_PASSWORD=

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
 language: php
 
+services:
+  # 5.6.x by default
+  - mysql
+
 php:
   - 7.1.3
   - 7.2
@@ -9,16 +13,20 @@ cache:
   directories:
     - $HOME/.composer/cache
 
+before_install:
+  - mysql -e 'CREATE DATABASE doika;'
+
 before_script:
   # disable xdebug if not coverage
   - if [[ $COVERAGE == "" ]]; then phpenv config-rm xdebug.ini; fi
-  - cp .env.example .env
+  - cp .env.ci .env
   - composer install --no-interaction --prefer-dist
   - php artisan key:generate
 
 script:
   - composer test:ci
   - php artisan route:list
+  - php artisan migrate:fresh --seed
 
 after_script:
   - |

--- a/laravel/Providers/AppServiceProvider.php
+++ b/laravel/Providers/AppServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\ServiceProvider;
 
 class AppServiceProvider extends ServiceProvider
@@ -21,8 +22,8 @@ class AppServiceProvider extends ServiceProvider
      *
      * @return void
      */
-    public function boot()
+    public function boot(): void
     {
-        //
+        Schema::defaultStringLength(191);
     }
 }


### PR DESCRIPTION
# Issue
Test migrations on CI (travis)
## Мэты

Мы мели праблемы з миграцыямі мы іх не тэсцілі на рэальнай mysql на CI, цяпер будзем :)

PS: мы выкарыстощваем sqlite для тэстаў (па дэфолту) які сябе паводзіць крыху па-іншаму чым  mysql


Гэты ПР амаль такі ж як "Setup mysql on travis for testing purposes" #348 але з гяленымі тэстамі і з болей гнуткім рашэннем