### PR TITLE
#357 Add a controller and test to upload images

### DIFF
--- a/routes/dashboard.php
+++ b/routes/dashboard.php
@@ -23,6 +23,8 @@ Route::delete('/donators/{id}', 'Dashboard\DonatorController@delete')->name('das
 Route::get('/settings', 'Dashboard\SettingsController@index')->name('dashboard.settings.index');
 Route::match(['POST', 'PUT'], '/settings', 'Dashboard\SettingsController@store')->name('dashboard.settings.store');
 
+Route::post('/images/upload', 'Dashboard\ImageUploadController@store')->name('dashboard.images.store');
+
 Route::get('/{vue_capture?}', 'Dashboard\DashboardController@index')
     ->where('vue_capture', '[\/\w\.-]*')
     ->name('dashboard.home');

--- a/src/Http/Controllers/Dashboard/ImageUploadController.php
+++ b/src/Http/Controllers/Dashboard/ImageUploadController.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Diglabby\Doika\Http\Controllers\Dashboard;
+
+use App\Http\Controllers\Controller;
+use Illuminate\Http\Request;
+
+final class ImageUploadController extends Controller
+{
+    /** Uploads a file as is and returns an URL to it */
+    public function store(Request $request): string
+    {
+        $this->validate($request, [
+            'image' => ['required', 'image'],
+        ]);
+
+        $image = $request->file('image');
+        \Storage::disk('public')->putFileAs('uploads', $image, $image->getClientOriginalName());
+
+        return \Storage::disk('public')->url("uploads/{$image->getClientOriginalName()}");
+    }
+}

--- a/tests/Feature/Http/Controllers/Dashboard/ImageUploadControllerTest.php
+++ b/tests/Feature/Http/Controllers/Dashboard/ImageUploadControllerTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Tests\Feature\Http\Controllers\Dashboard;
+
+use Illuminate\Http\Response;
+use Illuminate\Http\UploadedFile;
+use Tests\TestCase;
+
+class ImageUploadControllerTest extends TestCase
+{
+    /** @test */
+    public function it_uploads_image()
+    {
+        $image = UploadedFile::fake()->image('my-cool-image.jpg');
+
+        $response = $this
+            ->withoutMiddleware([\App\Http\Middleware\Authenticate::class])
+            ->post(route('dashboard.images.store'), ['image' => $image]);
+
+        $response->assertOk();
+        $url = $response->baseResponse->content();
+        $this->assertContains('my-cool-image.jpg', $url);
+    }
+
+    /** @test */
+    public function it_forbids_to_upload_not_an_image()
+    {
+        $nonImage = UploadedFile::fake()->create('my-cool-document.txt', 20);
+
+        $response = $this
+            ->withoutMiddleware([\App\Http\Middleware\Authenticate::class])
+            ->postJson(route('dashboard.images.store'), ['image' => $nonImage]);
+
+        $response->assertStatus(Response::HTTP_UNPROCESSABLE_ENTITY);
+        $response->assertJsonValidationErrors('image');
+    }
+}


### PR DESCRIPTION
## Issue
Implement image uploading, Closes #357

## Description

Самая проста рэалізацыя пакуль што: па URL `/doika/dashboard/images/upload` трэба передаць файл, назва поля (input name): `image`. А адказ вяртаецца URL на файл

Калі запыт не валідный -- ваяртаецца 422 адказ, прыклад:
```json
{
  "message": "The given data was invalid.",
  "errors": {
    "image": [
      "The image must be an image."
    ]
  }
}
```

Адзіны нюанс: файл аплоадзіцца у тэчку storage, а яна не ў public. Каб залітыя файлы былі даступныя, трэба рабіць сімлінк камандай `php artisan storage:link`

Падрабязней тут https://laravel.com/docs/master/filesystem#configuration , глава "The Public Disk"